### PR TITLE
Fix/made Tooltip component styling customizable

### DIFF
--- a/packages/themed-native-base/src/components/Tooltip/index.tsx
+++ b/packages/themed-native-base/src/components/Tooltip/index.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement, forwardRef } from 'react';
 import { Root, Content, Text } from './styled-components';
 import { createTooltip } from '@gluestack-ui/tooltip';
+import { usePropResolution } from '../../hooks/usePropResolution';
 import { GenericComponentType } from '../../types';
 import { AnimatePresence } from '@gluestack-style/animation-resolver';
 
@@ -13,15 +14,16 @@ const AccessibleTooltip = createTooltip({
 
 const TooltipTemp = forwardRef(
   ({ children, label, ...props }: any, ref?: any) => {
+    const resolvedPropForGluestack = usePropResolution(props);
     return (
       <AccessibleTooltip
-        {...props}
+        {...resolvedPropForGluestack}
         ref={ref}
         trigger={(triggerProps: any) => {
           return cloneElement(children, { ...triggerProps });
         }}
       >
-        <AccessibleTooltip.Content>
+        <AccessibleTooltip.Content {...resolvedPropForGluestack}>
           <AccessibleTooltip.Text>{label}</AccessibleTooltip.Text>
         </AccessibleTooltip.Content>
       </AccessibleTooltip>


### PR DESCRIPTION
Fixed the style of the Tooltip component to be customizable via `bg` and `_text` props as shown in the example below
https://docs.nativebase.io/tooltip#h3-customizing-tooltip

```tsx
<Tooltip
  label="Hello world"
  bg="pink"
  _text={{ color: 'white' }}
>
  <Button>More</Button>
</Tooltip>
```